### PR TITLE
Remove version attribute

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3"
-
 services:
   web:
     image: poljpocket/processwire


### PR DESCRIPTION
Every time I fire this up, docker complains that "the attribute 'version' is obsolete, it will be ignored, please remove it to avoid potential confusion"